### PR TITLE
fix: 修复文档识别http请求中忽略区域检测功能索引超出范围的问题

### DIFF
--- a/UmiOCR-data/py_src/server/doc_server.py
+++ b/UmiOCR-data/py_src/server/doc_server.py
@@ -471,6 +471,19 @@ def init(UmiWeb):
                     "code": 107,
                     "data": f"[Error] Invalid JSON format: {options} | {e}",
                 }
+
+            # 检查忽略区域参数是否存在, 若存在则补全坐标 (兼容桌面程序)
+            if "tbpu.ignoreArea" in options:
+                ignore_area = list()
+                for area in options["tbpu.ignoreArea"]:
+                    ignore_area.append([
+                        [area[0][0], area[0][1]],  # 左上角
+                        [area[1][0], area[0][1]],  # 右上角
+                        [area[1][0], area[1][1]],  # 右下角
+                        [area[0][0], area[1][1]],  # 左下角
+                    ])
+                options["tbpu.ignoreArea"] = ignore_area
+
         if not isinstance(options, dict):
             options = {}
 


### PR DESCRIPTION
问题：
执行文档识别 http 请求，如果增加 tbpu.ignoreArea 参数，且只传了左上角和右下角坐标，那么会报如下错误：UmiOCR-data\\py_src\\ocr\\tbpu\\ignore_area.py, line 17, in isInBox\n    and a[2][0] >= b[2][0]\nIndexError: list index out of range

原因：
1. isInBox 函数默认传入的忽略区域参数为四个角的坐标
2. 桌面程序绘制忽略区域时传入的是 4 个角的坐标
3. http 请求时传入的是 2 个角的坐标