### PR TITLE
feat: add macOS (darwin) platform support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 命名规范.md
 Temp
 build
+dist
 PyStand_for_UmiOCR/build
 .vscode
 *.exe
@@ -29,6 +30,8 @@ UmiOCR-data/site-packages*
 UmiOCR-data/runtime
 UmiOCR-data/lib
 UmiOCR-data/plugins/*/
+# Track macOS plugin during development (will move to runtime repo later)
+!UmiOCR-data/plugins/darwin_RapidOCR-json/
 UmiOCR-data/temp
 UmiOCR-data/temp_doc
 # 允许运行环境压缩包
@@ -37,3 +40,6 @@ UmiOCR-data/temp_doc
 # 排除缓存
 **__pycache__**
 UmiOCR-data/i18n/_
+
+# macOS
+.DS_Store

--- a/UmiOCR-data/main.py
+++ b/UmiOCR-data/main.py
@@ -30,22 +30,21 @@ SOFTWARE.
 
 
 """
-======================================================
-========== Umi-OCR Windows 运行环境初始化入口 ==========
-======================================================
+=============================================
+========== Umi-OCR 运行环境初始化入口 ==========
+=============================================
 
 说明：
-本文件负责 Windows + PyStand 运行环境的初始化，主要涉及：
+本文件负责运行环境的初始化，主要涉及：
 - 创建底层弹窗接口 os.MessageBox
 - 重定向标准输入输出流
 - 指定工作目录为 "/UmiOCR-data"
 - 添加Python库搜索目录 "site-packages"
 - 添加PySide2插件搜索目录 "PySide2/plugins"
 
-环境初始化后，调用正式入口 py_src/run.py 启动软件。
+支持平台：Windows (PyStand), Linux, macOS
 
-耗时分析：
-runtime/python.exe -X importtime main.py
+环境初始化后，调用正式入口 py_src/run.py 启动软件。
 """
 
 
@@ -66,22 +65,26 @@ def MessageBox(msg, type_="error"):
     elif type_ == "warning":
         info = "【警告】 Umi-OCR Warning"
     try:
-        # 通过 ctypes 发起弹窗
-        import ctypes
+        if sys.platform == "win32":
+            import ctypes
 
-        ctypes.windll.user32.MessageBoxW(None, str(msg), str(info), 0)
+            ctypes.windll.user32.MessageBoxW(None, str(msg), str(info), 0)
+        elif sys.platform == "darwin":
+            # macOS: 使用 osascript 显示弹窗
+            escaped = str(msg).replace("\\", "\\\\").replace('"', '\\"')
+            subprocess.Popen(
+                [
+                    "osascript",
+                    "-e",
+                    f'display dialog "{escaped}" with title "{info}" buttons {{"OK"}} default button "OK"',
+                ]
+            )
+        else:
+            # Linux 及其他: 打印到 stderr
+            print(f"{info}: {msg}", file=sys.stderr)
     except Exception:
-        # 部分系统，连ctypes也用不了。转为在新的控制台窗口中打印信息。
-        msg_cmd = (
-            msg.replace("^", "^^")
-            .replace("&", "^&")
-            .replace("<", "^<")
-            .replace(">", "^>")
-            .replace("|", "^|")
-            .replace("\n\n", "___")
-            .replace("\n", "___")
-        )
-        subprocess.Popen(["start", "cmd", "/k", f"echo {info}: {msg_cmd}"], shell=True)
+        # 最后防线：打印到 stderr
+        print(f"{info}: {msg}", file=sys.stderr)
     return 0
 
 
@@ -92,16 +95,23 @@ def initRuntimeEnvironment():
     """初始化运行环境"""
 
     # 尝试获取控制台的输出对象
-    try:
-        fd = os.open("CONOUT$", os.O_RDWR | os.O_BINARY)
-        fp = os.fdopen(fd, "w", encoding="utf-8")
-    except Exception as e:
-        fp = open(os.devnull, "w", encoding="utf-8")
-    # 输出流不存在时，重定向到控制台
-    if not sys.stdout:
-        sys.stdout = fp
-    if not sys.stderr:
-        sys.stderr = fp
+    if sys.platform == "win32":
+        # Windows: PyStand 环境下 stdout/stderr 可能为空，需要重定向到控制台
+        try:
+            fd = os.open("CONOUT$", os.O_RDWR | os.O_BINARY)
+            fp = os.fdopen(fd, "w", encoding="utf-8")
+        except Exception as e:
+            fp = open(os.devnull, "w", encoding="utf-8")
+        if not sys.stdout:
+            sys.stdout = fp
+        if not sys.stderr:
+            sys.stderr = fp
+    else:
+        # Unix (macOS/Linux): stdout/stderr 通常可用，仅在缺失时兜底
+        if not sys.stdout:
+            sys.stdout = open(os.devnull, "w", encoding="utf-8")
+        if not sys.stderr:
+            sys.stderr = open(os.devnull, "w", encoding="utf-8")
     # def except_hook(cls, exception, traceback):
     #     sys.__excepthook__(cls, exception, traceback)
     # sys.excepthook = except_hook
@@ -117,7 +127,11 @@ def initRuntimeEnvironment():
     # 初始化Qt搜索路径为相对路径，避免上层目录存在中文编码
     from PySide2.QtCore import QCoreApplication
 
-    QCoreApplication.addLibraryPath("./site-packages/PySide2/plugins")
+    if sys.platform == "darwin":
+        # macOS uses PySide6 via compatibility shim — plugins are at a different path
+        QCoreApplication.addLibraryPath("./site-packages/PySide6/Qt/plugins")
+    else:
+        QCoreApplication.addLibraryPath("./site-packages/PySide2/plugins")
 
 
 if __name__ == "__main__":
@@ -141,7 +155,11 @@ if __name__ == "__main__":
         # 启动正式入口
         from py_src.run import main
 
-        main(app_path=app_path, engineAddImportPath="./site-packages/PySide2/qml")
+        if sys.platform == "darwin":
+            qml_path = "./site-packages/PySide6/Qt/qml"
+        else:
+            qml_path = "./site-packages/PySide2/qml"
+        main(app_path=app_path, engineAddImportPath=qml_path)
     except Exception:
         err = traceback.format_exc()
         from py_src.imports.umi_log import logger, Logs_Dir

--- a/UmiOCR-data/plugins/darwin_RapidOCR-json/__init__.py
+++ b/UmiOCR-data/plugins/darwin_RapidOCR-json/__init__.py
@@ -1,0 +1,49 @@
+# darwin_RapidOCR-json — macOS OCR plugin using RapidOCR + ONNX Runtime (CoreML EP)
+#
+# Uses RapidOCR with PP-OCRv4 ONNX models. On Apple Silicon Macs, enables
+# CoreML Execution Provider for GPU/Neural Engine acceleration.
+# Falls back to CPU on Intel Macs or if CoreML EP is unavailable.
+
+from .rapid_ocr_api import RapidOcrApi
+
+# Plugin info registered by the plugin controller
+PluginInfo = {
+    "group": "ocr",
+    "api_class": RapidOcrApi,
+    # Global options: shown in the global settings panel under OCR API
+    "global_options": {
+        "title": "RapidOCR (macOS)",
+        "type": "group",
+        "use_coreml": {
+            "title": "GPU加速 (CoreML)",
+            "toolTip": "使用 Apple CoreML 加速推理（Apple Silicon 上启用 GPU / Neural Engine）。Intel Mac 自动回退到 CPU。",
+            "default": True,
+        },
+        "model_type": {
+            "title": "模型规格",
+            "toolTip": "mobile 模型速度更快，server 模型精度更高。",
+            "optionsList": [
+                ["mobile", "mobile（轻量，推荐）"],
+                ["server", "server（高精度）"],
+            ],
+            "default": "mobile",
+        },
+    },
+    # Local options: shown per-task in each tab page's settings
+    "local_options": {
+        "title": "文字识别",
+        "type": "group",
+        "language": {
+            "title": "识别语言",
+            "toolTip": "选择要识别的文字语言。",
+            "optionsList": [
+                ["ch", "简体中文+英文"],
+                ["ch_cht", "繁體中文+英文"],
+                ["en", "English"],
+                ["japan", "日本語"],
+                ["korean", "한국어"],
+            ],
+            "default": "ch",
+        },
+    },
+}

--- a/UmiOCR-data/plugins/darwin_RapidOCR-json/rapid_ocr_api.py
+++ b/UmiOCR-data/plugins/darwin_RapidOCR-json/rapid_ocr_api.py
@@ -1,0 +1,228 @@
+# RapidOCR API implementation for macOS with CoreML EP support
+
+import os
+import sys
+import base64
+import io
+
+from umi_log import logger
+
+
+class RapidOcrApi:
+    def __init__(self, argd):
+        self.argd = argd
+        self.engine = None
+        self._coreml_available = False
+        self._patched = False
+
+    def start(self, argd):
+        """Initialize or reconfigure the RapidOCR engine."""
+        try:
+            use_coreml = argd.get("use_coreml", True)
+            lang = argd.get("language", "ch")
+            model_type = argd.get("model_type", "mobile")
+
+            # Check if engine needs to be recreated
+            need_recreate = (
+                self.engine is None
+                or self.argd.get("language") != lang
+                or self.argd.get("model_type") != model_type
+                or self.argd.get("use_coreml") != use_coreml
+            )
+            self.argd = argd
+
+            if not need_recreate:
+                return "[Success]"
+
+            # Stop existing engine
+            if self.engine is not None:
+                self.stop()
+
+            # Apply CoreML EP monkey-patch before importing rapidocr
+            if use_coreml and sys.platform == "darwin":
+                self._apply_coreml_patch()
+            elif self._patched:
+                self._remove_coreml_patch()
+
+            try:
+                from rapidocr import RapidOCR, EngineType, LangDet, LangRec, ModelType
+            except ImportError:
+                msg = (
+                    "OCR engine not installed.\n"
+                    "OCR 引擎未安装。\n\n"
+                    "Please run install_ocr.command in the app bundle to install,\n"
+                    "or run in Terminal:\n"
+                    "  pip install rapidocr onnxruntime\n\n"
+                    "请双击 .app 包中的 install_ocr.command 安装 OCR 引擎。"
+                )
+                logger.error(msg)
+                return f"[Error] {msg}"
+
+            # Map UI language key to RapidOCR enums
+            det_lang_map = {
+                "ch": LangDet.CH,
+                "en": LangDet.EN,
+                "ch_cht": LangDet.CH,
+                "japan": LangDet.MULTI,
+                "korean": LangDet.MULTI,
+            }
+            rec_lang_map = {
+                "ch": LangRec.CH,
+                "en": LangRec.EN,
+                "ch_cht": LangRec.CHINESE_CHT,
+                "japan": LangRec.JAPAN,
+                "korean": LangRec.KOREAN,
+            }
+
+            # Build params dict
+            params = {
+                "Det.engine_type": EngineType.ONNXRUNTIME,
+                "Cls.engine_type": EngineType.ONNXRUNTIME,
+                "Rec.engine_type": EngineType.ONNXRUNTIME,
+                "Det.lang_type": det_lang_map.get(lang, LangDet.CH),
+                "Rec.lang_type": rec_lang_map.get(lang, LangRec.CH),
+            }
+
+            # Set model type (mobile = faster, server = more accurate)
+            mt = ModelType.SERVER if model_type == "server" else ModelType.MOBILE
+            params["Det.model_type"] = mt
+            params["Rec.model_type"] = mt
+
+            self.engine = RapidOCR(params=params)
+
+            ep_info = "CoreML EP" if self._coreml_available else "CPU"
+            logger.info(f"RapidOCR engine started: lang={lang}, model={model_type}, backend={ep_info}")
+            return "[Success]"
+
+        except Exception as e:
+            logger.error(f"Failed to start RapidOCR: {e}", exc_info=True)
+            return f"[Error] Failed to initialize RapidOCR engine: {e}"
+
+    def stop(self):
+        """Stop the OCR engine and clean up resources."""
+        self.engine = None
+        if self._patched:
+            self._remove_coreml_patch()
+
+    def runPath(self, img_path):
+        """Run OCR on an image file path."""
+        if not self.engine:
+            return {"code": 901, "data": "[Error] Engine not initialized"}
+        try:
+            result = self.engine(img_path)
+            return self._format_result(result)
+        except Exception as e:
+            logger.error(f"runPath failed: {e}", exc_info=True)
+            return {"code": 902, "data": f"[Error] OCR failed: {e}"}
+
+    def runBytes(self, img_bytes):
+        """Run OCR on raw image bytes."""
+        if not self.engine:
+            return {"code": 901, "data": "[Error] Engine not initialized"}
+        try:
+            result = self.engine(img_bytes)
+            return self._format_result(result)
+        except Exception as e:
+            logger.error(f"runBytes failed: {e}", exc_info=True)
+            return {"code": 902, "data": f"[Error] OCR failed: {e}"}
+
+    def runBase64(self, img_base64):
+        """Run OCR on a base64-encoded image string."""
+        if not self.engine:
+            return {"code": 901, "data": "[Error] Engine not initialized"}
+        try:
+            img_bytes = base64.b64decode(img_base64)
+            result = self.engine(img_bytes)
+            return self._format_result(result)
+        except Exception as e:
+            logger.error(f"runBase64 failed: {e}", exc_info=True)
+            return {"code": 902, "data": f"[Error] OCR failed: {e}"}
+
+    def _format_result(self, result):
+        """Convert RapidOCR result to Umi-OCR format.
+
+        RapidOCR result has:
+          result.boxes  - numpy array (N, 4, 2) or None
+          result.txts   - tuple of strings or None
+          result.scores - tuple of floats or None
+
+        Umi-OCR expects:
+          {"code": 100, "data": [{"text", "score", "box", "end"}, ...]}
+        """
+        if result is None or result.boxes is None or len(result.boxes) == 0:
+            return {"code": 100, "data": []}
+
+        data = []
+        boxes = result.boxes
+        txts = result.txts
+        scores = result.scores
+
+        for i in range(len(txts)):
+            # box: numpy array (4, 2) -> list of [x, y] pairs
+            box = boxes[i].tolist() if hasattr(boxes[i], "tolist") else list(boxes[i])
+            data.append(
+                {
+                    "text": txts[i],
+                    "score": float(scores[i]),
+                    "box": box,
+                    "end": "",
+                }
+            )
+
+        return {"code": 100, "data": data}
+
+    def _apply_coreml_patch(self):
+        """Monkey-patch onnxruntime.InferenceSession to use CoreML EP on macOS."""
+        if self._patched:
+            return
+        try:
+            import onnxruntime as ort
+
+            if "CoreMLExecutionProvider" not in ort.get_available_providers():
+                logger.info("CoreML EP not available, using CPU only")
+                self._coreml_available = False
+                return
+
+            self._coreml_available = True
+            self._original_session_init = ort.InferenceSession.__init__
+
+            coreml_providers = [
+                (
+                    "CoreMLExecutionProvider",
+                    {
+                        "ModelFormat": "MLProgram",
+                        "MLComputeUnits": "ALL",
+                    },
+                ),
+                "CPUExecutionProvider",
+            ]
+
+            original_init = self._original_session_init
+
+            def patched_init(session_self, *args, **kwargs):
+                # Inject CoreML providers if not explicitly set
+                if "providers" not in kwargs or kwargs["providers"] is None:
+                    kwargs["providers"] = coreml_providers
+                return original_init(session_self, *args, **kwargs)
+
+            ort.InferenceSession.__init__ = patched_init
+            self._patched = True
+            logger.info("CoreML EP patch applied for GPU/ANE acceleration")
+
+        except ImportError:
+            logger.warning("onnxruntime not found, CoreML EP unavailable")
+            self._coreml_available = False
+
+    def _remove_coreml_patch(self):
+        """Remove the CoreML EP monkey-patch."""
+        if not self._patched:
+            return
+        try:
+            import onnxruntime as ort
+
+            if hasattr(self, "_original_session_init"):
+                ort.InferenceSession.__init__ = self._original_session_init
+            self._patched = False
+            logger.info("CoreML EP patch removed")
+        except ImportError:
+            pass

--- a/UmiOCR-data/py_src/event_bus/key_mouse/keyboard.py
+++ b/UmiOCR-data/py_src/event_bus/key_mouse/keyboard.py
@@ -1,3 +1,5 @@
+import sys
+
 from pynput import keyboard
 from PySide2.QtCore import QMutex
 from time import time
@@ -126,6 +128,15 @@ class _HotkeyController:
     # 第一次注册热键时，启动监听
     def _start(self):
         if not self._listener:
+            # macOS 辅助功能权限检查
+            if sys.platform == "darwin":
+                if not Platform.checkAccessibilityPermission():
+                    logger.warning(
+                        "macOS 辅助功能权限未授权，全局快捷键可能不可用。"
+                        "请前往 系统设置 > 隐私与安全性 > 辅助功能 中授权本应用。\n"
+                        "Accessibility permission not granted. Global hotkeys may not work. "
+                        "Please grant access in System Settings > Privacy & Security > Accessibility."
+                    )
             self._listener = keyboard.Listener(
                 on_press=self._onPress, on_release=self._onRelease
             )

--- a/UmiOCR-data/py_src/image_controller/screenshot_controller.py
+++ b/UmiOCR-data/py_src/image_controller/screenshot_controller.py
@@ -5,6 +5,7 @@
 from ..image_controller.image_provider import PixmapProvider  # 图片提供器
 from ..utils.file_finder import findFiles
 
+import sys
 import time
 from PySide2.QtGui import QGuiApplication, QClipboard, QImage, QPixmap  # 截图 剪贴板
 
@@ -25,6 +26,17 @@ class _ScreenshotControllerClass:
         """
         if wait > 0:
             time.sleep(wait)
+        # macOS 屏幕录制权限检查
+        if sys.platform == "darwin":
+            from ..platform import Platform
+
+            if not Platform.checkScreenRecordingPermission():
+                return [
+                    {
+                        "imgID": "[Error] macOS 需要屏幕录制权限。请前往 系统设置 > 隐私与安全性 > 屏幕录制 中授权本应用。\n"
+                        "[Error] Screen Recording permission required. Please grant access in System Settings > Privacy & Security > Screen Recording."
+                    }
+                ]
         try:
             grabList = []
             screensList = QGuiApplication.screens()

--- a/UmiOCR-data/py_src/imports/umi_log.py
+++ b/UmiOCR-data/py_src/imports/umi_log.py
@@ -29,6 +29,7 @@ import os
 import sys
 import json
 import logging
+import subprocess
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from logging import LogRecord
@@ -267,4 +268,11 @@ def change_save_log_level(levelname):
 
 # 打开日志保存目录
 def open_logs_dir():
-    os.startfile(Logs_Dir)
+    import sys
+
+    if sys.platform == "win32":
+        os.startfile(Logs_Dir)
+    elif sys.platform == "darwin":
+        subprocess.Popen(["open", Logs_Dir])
+    else:
+        subprocess.Popen(["xdg-open", Logs_Dir])

--- a/UmiOCR-data/py_src/ocr/output/output_pdf_layered.py
+++ b/UmiOCR-data/py_src/ocr/output/output_pdf_layered.py
@@ -112,7 +112,7 @@ class OutputPdfLayered(Output):
             page.insert_text(
                 point,
                 text,
-                fontsize,
+                fontsize=fontsize,
                 fontname="cjk",
                 rotate=protation,  # 文本角度设定
                 stroke_opacity=self.opacity,  # 描边透明度

--- a/UmiOCR-data/py_src/platform/__init__.py
+++ b/UmiOCR-data/py_src/platform/__init__.py
@@ -8,7 +8,7 @@ if _plat.startswith("win32"):
 elif _plat.startswith("linux"):
     from .linux.linux_api import Api as _Platform
 elif _plat.startswith("darwin"):
-    raise ImportError("尚未支持macos系统！")
+    from .darwin.darwin_api import Api as _Platform
 else:
     raise ImportError(f"未知系统：{_plat}")
 

--- a/UmiOCR-data/py_src/platform/darwin/darwin_api.py
+++ b/UmiOCR-data/py_src/platform/darwin/darwin_api.py
@@ -1,0 +1,225 @@
+# ==============================================
+# =============== macOS 系统API ===============
+# ==============================================
+
+import os
+import shlex
+import subprocess
+from PySide2.QtCore import QStandardPaths as Qsp
+
+from umi_log import logger
+from umi_about import UmiAbout
+from .key_translator import getKeyName
+
+
+# ==================== 快捷方式 ====================
+class _Shortcut:
+    @staticmethod
+    def _getPath(position):
+        # 桌面
+        if position == "desktop":
+            return Qsp.writableLocation(Qsp.DesktopLocation)
+        # 应用程序（/Applications 或 ~/Applications）
+        elif position == "startMenu":
+            return Qsp.writableLocation(Qsp.ApplicationsLocation)
+        # 开机自启：macOS 使用 LaunchAgents
+        elif position == "startup":
+            return os.path.expanduser("~/Library/LaunchAgents")
+
+    # 创建快捷方式（macOS 符号链接），返回成功与否的字符串。position取值：
+    # desktop 桌面
+    # startMenu 应用程序
+    # startup 开机自启
+    @staticmethod
+    def createShortcut(position):
+        lnkName = UmiAbout["name"]
+        appPath = UmiAbout["app"]["path"]
+        appDir = UmiAbout["app"]["dir"]
+        if not appPath:
+            return (
+                f"[Error] 未找到程序入口文件。请尝试手动创建快捷方式。\n"
+                f"[Error] App path not exist. Please try creating a shortcut manually.\n\n{appPath}"
+            )
+
+        if position == "startup":
+            # macOS 开机自启通过 LaunchAgent plist 实现
+            return _Shortcut._createLaunchAgent(lnkName, appPath, appDir)
+
+        # desktop / startMenu：创建符号链接
+        try:
+            lnkDir = _Shortcut._getPath(position)
+            lnkPathBase = os.path.join(lnkDir, lnkName)
+            lnkPath = lnkPathBase
+            i = 1
+            while os.path.exists(lnkPath):
+                lnkPath = f"{lnkPathBase} ({i})"
+                i += 1
+            os.symlink(appPath, lnkPath)
+            logger.info(f"创建快捷方式： {lnkPath}")
+            return "[Success]"
+        except Exception as e:
+            return (
+                f"[Error] 创建快捷方式失败。\n"
+                f"[Error] Failed to create shortcut.\n {lnkPath}: {e}"
+            )
+
+    @staticmethod
+    def _createLaunchAgent(lnkName, appPath, appDir):
+        """创建 macOS LaunchAgent plist 实现开机自启"""
+        plistName = f"com.umi-ocr.{lnkName}.plist"
+        plistDir = _Shortcut._getPath("startup")
+        os.makedirs(plistDir, exist_ok=True)
+        plistPath = os.path.join(plistDir, plistName)
+
+        plistContent = f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.umi-ocr.{lnkName}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{appPath}</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>{appDir}</string>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+"""
+        try:
+            with open(plistPath, "w") as f:
+                f.write(plistContent)
+            logger.info(f"创建开机自启 LaunchAgent： {plistPath}")
+            return "[Success]"
+        except Exception as e:
+            return (
+                f"[Error] 创建开机自启失败。\n"
+                f"[Error] Failed to create LaunchAgent.\n {plistPath}: {e}"
+            )
+
+    # 删除快捷方式，返回删除文件的个数
+    @staticmethod
+    def deleteShortcut(position):
+        try:
+            appName = UmiAbout["name"]
+            lnkDir = _Shortcut._getPath(position)
+        except Exception:
+            logger.error("无法获取应用信息", exc_info=True, stack_info=True)
+            return 0
+
+        num = 0
+        if not os.path.isdir(lnkDir):
+            return 0
+
+        for fileName in os.listdir(lnkDir):
+            try:
+                lnkPath = os.path.join(lnkDir, fileName)
+                if position == "startup":
+                    # LaunchAgent plist 文件
+                    if appName.lower() in fileName.lower() and fileName.endswith(
+                        ".plist"
+                    ):
+                        os.remove(lnkPath)
+                        num += 1
+                        logger.info(f"删除开机自启： {lnkPath}")
+                else:
+                    # 符号链接
+                    if os.path.islink(lnkPath) and appName in fileName:
+                        os.remove(lnkPath)
+                        num += 1
+                        logger.info(f"删除快捷方式： {lnkPath}")
+            except Exception:
+                logger.error(
+                    f"删除快捷方式失败。 lnkPath: {lnkPath}",
+                    exc_info=True,
+                    stack_info=True,
+                )
+                continue
+        return num
+
+
+# ==================== 硬件控制 ====================
+class _HardwareCtrl:
+    # 关机
+    @staticmethod
+    def shutdown():
+        os.system(
+            'osascript -e \'tell application "System Events" to shut down\''
+        )
+
+    # 休眠（macOS 使用 pmset sleepnow）
+    @staticmethod
+    def hibernate():
+        os.system("pmset sleepnow")
+
+
+# ==================== 对外接口 ====================
+class Api:
+    # 快捷方式。接口： createShortcut deleteShortcut
+    # 参数：快捷方式位置， desktop startMenu startup
+    Shortcut = _Shortcut()
+
+    # 硬件控制。接口： shutdown hibernate
+    HardwareCtrl = _HardwareCtrl()
+
+    # 根据系统及硬件，判断最适合的渲染器类型
+    @staticmethod
+    def getOpenGLUse():
+        # macOS: Qt6 uses RHI which auto-selects Metal on Apple Silicon.
+        # Desktop OpenGL avoids the GLES compatibility check that would
+        # show a spurious warning dialog (macOS doesn't expose GLES).
+        return "AA_UseDesktopOpenGL"
+
+    # 键值转键名
+    @staticmethod
+    def getKeyName(key):
+        return getKeyName(key)
+
+    # 让系统运行一个程序，不堵塞当前进程
+    @staticmethod
+    def runNewProcess(path, args=""):
+        command_line = [path] + shlex.split(args)
+        subprocess.Popen(command_line)
+
+    # 用系统默认应用打开一个文件或目录，不堵塞当前进程
+    @staticmethod
+    def startfile(path):
+        subprocess.Popen(["open", path])
+
+    # 检查 macOS 屏幕录制权限
+    @staticmethod
+    def checkScreenRecordingPermission():
+        """检查并请求 macOS 屏幕录制权限。返回 True 表示已授权。"""
+        try:
+            import ctypes
+            import ctypes.util
+
+            cg = ctypes.cdll.LoadLibrary(ctypes.util.find_library("CoreGraphics"))
+            cg.CGPreflightScreenCaptureAccess.restype = ctypes.c_bool
+            if not cg.CGPreflightScreenCaptureAccess():
+                # 请求权限（触发系统弹窗）
+                cg.CGRequestScreenCaptureAccess.restype = ctypes.c_bool
+                cg.CGRequestScreenCaptureAccess()
+                return False
+            return True
+        except Exception:
+            return True  # 无法检查时默认允许（旧版 macOS）
+
+    # 检查 macOS 辅助功能权限
+    @staticmethod
+    def checkAccessibilityPermission():
+        """检查 macOS 辅助功能权限。返回 True 表示已授权。"""
+        try:
+            import ctypes
+            import ctypes.util
+
+            lib = ctypes.cdll.LoadLibrary(
+                ctypes.util.find_library("ApplicationServices")
+            )
+            lib.AXIsProcessTrusted.restype = ctypes.c_bool
+            return lib.AXIsProcessTrusted()
+        except Exception:
+            return True  # 无法检查时默认允许

--- a/UmiOCR-data/py_src/platform/darwin/key_translator.py
+++ b/UmiOCR-data/py_src/platform/darwin/key_translator.py
@@ -1,0 +1,76 @@
+# 负责 pynput 的按键转换
+# macOS 平台实现：不依赖 win32 的 KeyTranslator
+
+from umi_log import logger
+
+
+# macOS 修饰键映射
+_MODIFIER_MAP = {
+    "cmd": "cmd",
+    "cmd_l": "cmd",
+    "cmd_r": "cmd",
+    "alt": "option",
+    "alt_l": "option",
+    "alt_r": "option",
+    "alt_gr": "option",
+    "ctrl": "ctrl",
+    "ctrl_l": "ctrl",
+    "ctrl_r": "ctrl",
+    "shift": "shift",
+    "shift_l": "shift",
+    "shift_r": "shift",
+    "caps_lock": "caps_lock",
+    "tab": "tab",
+    "space": "space",
+    "enter": "enter",
+    "backspace": "backspace",
+    "delete": "delete",
+    "escape": "esc",
+    "f1": "f1",
+    "f2": "f2",
+    "f3": "f3",
+    "f4": "f4",
+    "f5": "f5",
+    "f6": "f6",
+    "f7": "f7",
+    "f8": "f8",
+    "f9": "f9",
+    "f10": "f10",
+    "f11": "f11",
+    "f12": "f12",
+    "up": "up",
+    "down": "down",
+    "left": "left",
+    "right": "right",
+    "home": "home",
+    "end": "end",
+    "page_up": "page_up",
+    "page_down": "page_down",
+}
+
+
+def getKeyName(key):
+    """传入pynput的Key对象，返回键名字符串"""
+    try:
+        if hasattr(key, "name"):  # 控制键（如 Key.cmd, Key.shift）
+            name = key.name
+            mapped = _MODIFIER_MAP.get(name)
+            if mapped:
+                return mapped
+            # 去除 _l _r 标记后缀
+            if "_" in name:
+                name = name.split("_", 1)[0].lower()
+            return name.lower()
+        elif hasattr(key, "char") and key.char:  # 字符键
+            return key.char.lower()
+        elif hasattr(key, "vk") and key.vk is not None:  # 无字符但有虚拟键码
+            return f"<{key.vk}>"
+        else:
+            return str(key)
+    except Exception:
+        logger.error(
+            f"键值转换异常！key: {str(key)}, type: {type(key)}.",
+            exc_info=True,
+            stack_info=True,
+        )
+        return str(key)

--- a/UmiOCR-data/py_src/platform/linux/linux_api.py
+++ b/UmiOCR-data/py_src/platform/linux/linux_api.py
@@ -156,4 +156,4 @@ class Api:
     # 用系统默认应用打开一个文件或目录，不堵塞当前进程
     @staticmethod
     def startfile(path):
-        os.startfile(path)
+        subprocess.Popen(["xdg-open", path])

--- a/UmiOCR-data/py_src/run.py
+++ b/UmiOCR-data/py_src/run.py
@@ -71,6 +71,9 @@ def runQml(engineAddImportPath):
     qtApp.setApplicationName(UmiAbout["name"])
     qtApp.setOrganizationName(UmiAbout["authors"][0]["name"])
     qtApp.setOrganizationDomain(UmiAbout["url"]["home"])
+    # macOS: 关闭所有窗口后不退出应用（保持 Dock 图标和菜单栏托盘运行）
+    if sys.platform == "darwin":
+        qtApp.setQuitOnLastWindowClosed(False)
 
     # ==================== 3. OpenGlES 兼容性检查 ====================
     app_opengl.checkOpengl()
@@ -111,6 +114,11 @@ def runQml(engineAddImportPath):
 
     # ==================== 6. 启动qml引擎 ====================
     engine = QQmlApplicationEngine()
+    # macOS: add Qt5 compat QML overlay FIRST so versioned imports (e.g. 1.3) resolve
+    if sys.platform == "darwin":
+        qt5compat = os.path.join(os.getcwd(), "qt5compat_qml")
+        if os.path.isdir(qt5compat):
+            engine.addImportPath(qt5compat)
     if engineAddImportPath:
         engine.addImportPath(engineAddImportPath)  # 相对路径重新导入包
     engine.addImageProvider("pixmapprovider", PixmapProvider)  # 注册图片提供器

--- a/UmiOCR-data/py_src/server/cmd_client.py
+++ b/UmiOCR-data/py_src/server/cmd_client.py
@@ -93,6 +93,18 @@ def _clip(text):
             finally:
                 os.unlink(temp_file_name)  # 删除临时文件
             print("\nSuccess copy to clipboard.")
+        elif os_type == "Darwin":
+            subprocess.run(
+                ["pbcopy"], input=text.encode("utf-8"), check=True
+            )
+            print("\nSuccess copy to clipboard.")
+        elif os_type == "Linux":
+            subprocess.run(
+                ["xclip", "-selection", "clipboard"],
+                input=text.encode("utf-8"),
+                check=True,
+            )
+            print("\nSuccess copy to clipboard.")
         else:
             print(f"[Error] clip unsupported OS: {os_type}")
     except Exception as e:

--- a/UmiOCR-data/py_src/utils/ocr_installer.py
+++ b/UmiOCR-data/py_src/utils/ocr_installer.py
@@ -1,0 +1,120 @@
+# OCR engine on-demand installer for macOS
+# Downloads and installs rapidocr + onnxruntime into site-packages.
+
+import os
+import sys
+import subprocess
+
+from umi_log import logger
+from ..event_bus.pubsub_service import PubSubService
+
+
+def is_ocr_installed():
+    """Check if the OCR engine dependencies are importable."""
+    try:
+        import rapidocr  # noqa: F401
+        import onnxruntime  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def install_ocr_engine():
+    """Install OCR dependencies via pip into the app's site-packages.
+
+    Publishes events:
+      - "ocr_install_progress": (message_str,)
+      - "ocr_install_done": (success_bool, message_str)
+    """
+    try:
+        # Find site-packages directory
+        sp_dir = None
+        for p in sys.path:
+            if p.endswith("site-packages") and os.path.isdir(p):
+                sp_dir = p
+                break
+
+        if not sp_dir:
+            sp_dir = os.path.join(os.getcwd(), "site-packages")
+
+        # Find requirements-ocr.txt
+        req_file = None
+        # Check in Resources/ (app bundle layout)
+        for candidate in [
+            os.path.join(os.getcwd(), "..", "requirements-ocr.txt"),
+            os.path.join(os.getcwd(), "requirements-ocr.txt"),
+        ]:
+            if os.path.isfile(candidate):
+                req_file = os.path.abspath(candidate)
+                break
+
+        PubSubService.publish(
+            "ocr_install_progress",
+            "正在下载 OCR 引擎...\nDownloading OCR engine..."
+        )
+        logger.info(f"Installing OCR engine to {sp_dir}")
+
+        # Build pip command
+        packages = ["rapidocr>=2.0.0", "onnxruntime>=1.17.0"]
+        cmd = [
+            sys.executable, "-m", "pip", "install",
+            "--target", sp_dir,
+            "--upgrade",
+        ]
+
+        if req_file:
+            cmd += ["-r", req_file]
+        else:
+            cmd += packages
+
+        # Ensure the subprocess can find pip in the bundled Python's own site-packages.
+        # The bundled Python's pip lives at <PYTHONHOME>/lib/pythonX.Y/site-packages/
+        env = os.environ.copy()
+        python_home = os.path.dirname(os.path.dirname(sys.executable))
+        py_ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
+        bundled_sp = os.path.join(python_home, "lib", py_ver, "site-packages")
+        if os.path.isdir(bundled_sp):
+            existing = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = bundled_sp + (":" + existing if existing else "")
+        env["PYTHONHOME"] = python_home
+
+        logger.info(f"Running: {' '.join(cmd)}")
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            env=env,
+        )
+
+        if result.returncode == 0:
+            logger.info("OCR engine installed successfully")
+            PubSubService.publish(
+                "ocr_install_done",
+                True,
+                "OCR 引擎安装成功！请重启应用。\nOCR engine installed! Please restart the app."
+            )
+        else:
+            err = result.stderr[-500:] if result.stderr else "Unknown error"
+            logger.error(f"pip install failed: {err}")
+            PubSubService.publish(
+                "ocr_install_done",
+                False,
+                f"安装失败 / Install failed:\n{err}"
+            )
+
+    except subprocess.TimeoutExpired:
+        logger.error("OCR install timed out")
+        PubSubService.publish(
+            "ocr_install_done",
+            False,
+            "安装超时，请检查网络连接。\nInstall timed out. Check your network."
+        )
+    except Exception as e:
+        logger.error(f"OCR install error: {e}", exc_info=True)
+        PubSubService.publish(
+            "ocr_install_done",
+            False,
+            f"安装出错 / Install error:\n{e}"
+        )

--- a/UmiOCR-data/py_src/utils/utils_connector.py
+++ b/UmiOCR-data/py_src/utils/utils_connector.py
@@ -5,6 +5,7 @@ from PySide2.QtCore import QObject, Slot
 
 from . import utils
 from . import file_finder  # 文件搜索器
+from . import ocr_installer  # OCR引擎安装器
 from ..platform import Platform  # 跨平台
 from .thread_pool import threadRun  # 异步执行函数
 
@@ -61,3 +62,14 @@ class UtilsConnector(QObject):
     @Slot("QVariant", result="QVariant")
     def QUrl2String(self, fileUrls):
         return utils.QUrl2String(fileUrls)
+
+    # 检查OCR引擎是否已安装
+    @Slot(result=bool)
+    def isOcrInstalled(self):
+        return ocr_installer.is_ocr_installed()
+
+    # 异步安装OCR引擎（通过 pubsub 事件返回进度和结果）
+    # 事件: "ocr_install_progress" (msg), "ocr_install_done" (success, msg)
+    @Slot()
+    def installOcrEngine(self):
+        threadRun(ocr_installer.install_ocr_engine)

--- a/UmiOCR-data/qt_res/qml/Configs/GlobalConfigs.qml
+++ b/UmiOCR-data/qt_res/qml/Configs/GlobalConfigs.qml
@@ -322,6 +322,8 @@ Configs {
         if(configDict.ocr)
             ocrManager.init2()
         console.log("GlobalConfig 初始化全局配置完毕！")
+        // macOS: 检查OCR引擎是否已安装，未安装则提示下载
+        Qt.callLater(checkOcrInstall)
         // 延迟执行
         Qt.callLater(()=>{
             setQmlToCmd()  // 将qml模块字典传入cmd执行模块
@@ -363,6 +365,54 @@ Configs {
             if(pluginInfos.options.ocr)
                 ocrManager.init1(pluginInfos.options.ocr)
         }
+    }
+
+    // macOS: OCR引擎安装完成的回调（由 pubsub 事件 "ocr_install_done" 触发）
+    function onOcrInstallDone(success, msg) {
+        qmlapp.popup.hideMask("ocr_install")
+        qmlapp.pubSub.unsubscribe("ocr_install_done", gRoot, "onOcrInstallDone")
+        if (success) {
+            qmlapp.popup.message(qsTr("安装成功"), msg +
+                "\n\n" + qsTr("请重新启动应用以使用 OCR 功能。"), "")
+        } else {
+            qmlapp.popup.message(qsTr("安装失败"), msg, "error")
+        }
+    }
+
+    // macOS: 检查OCR引擎是否已安装
+    function checkOcrInstall() {
+        if (Qt.platform.os !== "osx") return
+        if (qmlapp.utilsConnector.isOcrInstalled()) return
+
+        // 订阅安装完成事件
+        qmlapp.pubSub.subscribe("ocr_install_done", gRoot, "onOcrInstallDone")
+
+        // 显示下载提示对话框
+        const msg = qsTr("OCR 识别引擎尚未安装，是否立即下载？") +
+            "\nOCR engine is not installed. Download now?" +
+            "\n\n" + qsTr("下载大小约 100 MB，安装后约占 400 MB。") +
+            "\nDownload: ~100 MB, installed: ~400 MB."
+
+        const argd = {
+            yesText: qsTr("立即下载"),
+            noText: qsTr("稍后再说"),
+        }
+        qmlapp.popup.dialog(
+            qsTr("安装 OCR 引擎"),
+            msg,
+            function(confirmed) {
+                if (confirmed) {
+                    qmlapp.popup.showMask(
+                        qsTr("正在下载并安装 OCR 引擎，请稍候...") +
+                        "\nDownloading OCR engine, please wait...",
+                        "ocr_install"
+                    )
+                    qmlapp.utilsConnector.installOcrEngine()
+                }
+            },
+            "",
+            argd
+        )
     }
 
     // 添加/删除快捷方式

--- a/UmiOCR-data/qt_res/qml/MainWindow/SystemTray.qml
+++ b/UmiOCR-data/qt_res/qml/MainWindow/SystemTray.qml
@@ -110,7 +110,9 @@ SystemTrayIcon {
     }
 
     onActivated: {
-        if(reason == SystemTrayIcon.DoubleClick)
+        // macOS 菜单栏图标惯例为单击打开，Windows/Linux 为双击
+        if(reason == SystemTrayIcon.DoubleClick ||
+           (reason == SystemTrayIcon.Trigger && Qt.platform.os === "osx"))
             qmlapp.mainWin.setVisibility(true) // 主窗可见
     }
 }

--- a/build_macos/Info.plist
+++ b/build_macos/Info.plist
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>Umi-OCR</string>
+
+    <key>CFBundleDisplayName</key>
+    <string>Umi-OCR</string>
+
+    <key>CFBundleIdentifier</key>
+    <string>com.hiroi-sora.umi-ocr</string>
+
+    <key>CFBundleVersion</key>
+    <string>2.1.5</string>
+
+    <key>CFBundleShortVersionString</key>
+    <string>2.1.5</string>
+
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+
+    <key>CFBundleSignature</key>
+    <string>????</string>
+
+    <key>CFBundleExecutable</key>
+    <string>umi-ocr</string>
+
+    <key>CFBundleIconFile</key>
+    <string>umiocr</string>
+
+    <key>LSMinimumSystemVersion</key>
+    <string>12.0</string>
+
+    <key>NSHighResolutionCapable</key>
+    <true/>
+
+    <key>LSUIElement</key>
+    <false/>
+
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+
+    <!-- Permission descriptions -->
+    <key>NSScreenCaptureUsageDescription</key>
+    <string>Umi-OCR needs screen recording permission to capture screenshots for OCR text recognition.</string>
+
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Umi-OCR needs Accessibility permission to register global hotkeys for screenshot capture.</string>
+
+    <key>NSCameraUsageDescription</key>
+    <string>Umi-OCR does not use the camera.</string>
+
+    <!-- Supported file types for drag-and-drop -->
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Image</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.image</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>PDF Document</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>com.adobe.pdf</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/build_macos/build.sh
+++ b/build_macos/build.sh
@@ -1,0 +1,419 @@
+#!/bin/bash
+# =============================================================
+# Umi-OCR macOS Build Script
+# =============================================================
+#
+# Creates a self-contained Umi-OCR.app bundle for macOS.
+#
+# Usage:
+#   ./build_macos/build.sh [--sign IDENTITY] [--python PATH]
+#
+# Options:
+#   --sign IDENTITY   Code-sign with the given Apple Developer identity
+#   --python PATH     Path to Python 3 to bundle (default: current python3)
+#   --skip-deps       Skip pip install (use existing site-packages)
+#
+# Output:
+#   dist/Umi-OCR.app
+#
+# Requirements:
+#   - macOS 12+ (Monterey)
+#   - Python 3.8+
+#   - pip
+#   - iconutil (ships with Xcode Command Line Tools)
+
+set -euo pipefail
+
+# ── Parse arguments ──────────────────────────────────────────
+
+SIGN_IDENTITY=""
+PYTHON_PATH=""
+SKIP_DEPS=false
+WITH_OCR=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --sign)      SIGN_IDENTITY="$2"; shift 2 ;;
+        --python)    PYTHON_PATH="$2"; shift 2 ;;
+        --skip-deps) SKIP_DEPS=true; shift ;;
+        --with-ocr)  WITH_OCR=true; shift ;;
+        *)           echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ── Resolve paths ────────────────────────────────────────────
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build_macos"
+DIST_DIR="${REPO_ROOT}/dist"
+APP_DIR="${DIST_DIR}/Umi-OCR.app"
+CONTENTS="${APP_DIR}/Contents"
+MACOS_DIR="${CONTENTS}/MacOS"
+RESOURCES="${CONTENTS}/Resources"
+
+PYTHON="${PYTHON_PATH:-$(which python3)}"
+
+echo "================================================"
+echo "  Umi-OCR macOS Build"
+echo "================================================"
+echo "  Repo:     ${REPO_ROOT}"
+echo "  Python:   ${PYTHON}"
+echo "  Output:   ${APP_DIR}"
+echo "  Sign:     ${SIGN_IDENTITY:-<unsigned>}"
+echo "================================================"
+echo
+
+# ── Validate ─────────────────────────────────────────────────
+
+if ! command -v "${PYTHON}" &>/dev/null; then
+    echo "ERROR: Python not found at ${PYTHON}"
+    exit 1
+fi
+
+PYTHON_VERSION=$("${PYTHON}" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+echo "Python version: ${PYTHON_VERSION}"
+
+if ! "${PYTHON}" -c "import sys; assert sys.version_info >= (3, 8), 'Python 3.8+ required'" 2>/dev/null; then
+    echo "ERROR: Python 3.8+ is required (found ${PYTHON_VERSION})"
+    exit 1
+fi
+
+# ── Clean previous build ────────────────────────────────────
+
+echo "Cleaning previous build..."
+rm -rf "${APP_DIR}"
+
+# ── Create .app bundle structure ─────────────────────────────
+
+echo "Creating .app bundle structure..."
+mkdir -p "${MACOS_DIR}"
+mkdir -p "${RESOURCES}"
+
+# ── Copy Info.plist ──────────────────────────────────────────
+
+# Read version from about.json and update Info.plist
+VERSION=$("${PYTHON}" -c "
+import json
+with open('${REPO_ROOT}/UmiOCR-data/about.json') as f:
+    d = json.load(f)
+v = d['version']
+s = f\"{v['major']}.{v['minor']}.{v['patch']}\"
+if v.get('prerelease'):
+    s += f\"-{v['prerelease']}.{v['prereleaseNumber']}\"
+print(s)
+")
+echo "App version: ${VERSION}"
+
+sed -e "s|<string>2.1.5</string>|<string>${VERSION}</string>|g" \
+    "${BUILD_DIR}/Info.plist" > "${CONTENTS}/Info.plist"
+
+# ── Create icon (.icns) ─────────────────────────────────────
+
+echo "Creating app icon..."
+ICO_FILE="${REPO_ROOT}/UmiOCR-data/qt_res/images/icons/umiocr.ico"
+ICONSET_DIR="${DIST_DIR}/umiocr.iconset"
+
+if command -v sips &>/dev/null && command -v iconutil &>/dev/null; then
+    # Extract the largest image from the .ico and create iconset
+    mkdir -p "${ICONSET_DIR}"
+
+    # Use Python + Pillow to extract icon sizes from .ico
+    "${PYTHON}" -c "
+from PIL import Image
+import os, sys
+
+ico = Image.open('${ICO_FILE}')
+iconset = '${ICONSET_DIR}'
+
+# Standard macOS icon sizes
+sizes = [16, 32, 64, 128, 256, 512]
+
+for size in sizes:
+    try:
+        img = ico.copy()
+        img = img.resize((size, size), Image.LANCZOS)
+        img.save(os.path.join(iconset, f'icon_{size}x{size}.png'))
+        # @2x retina version (e.g., icon_16x16@2x.png is 32x32 pixels)
+        if size <= 256:
+            img2x = ico.copy()
+            img2x = img2x.resize((size * 2, size * 2), Image.LANCZOS)
+            img2x.save(os.path.join(iconset, f'icon_{size}x{size}@2x.png'))
+    except Exception as e:
+        print(f'Warning: Could not create {size}x{size} icon: {e}', file=sys.stderr)
+" 2>/dev/null
+
+    iconutil -c icns -o "${RESOURCES}/umiocr.icns" "${ICONSET_DIR}" 2>/dev/null && \
+        echo "  Created umiocr.icns" || \
+        echo "  Warning: iconutil failed, app will use default icon"
+    rm -rf "${ICONSET_DIR}"
+else
+    echo "  Warning: sips/iconutil not found. App will use default icon."
+    echo "  Install Xcode Command Line Tools: xcode-select --install"
+fi
+
+# ── Copy launcher script ────────────────────────────────────
+
+echo "Installing launcher..."
+cp "${BUILD_DIR}/umi-ocr.sh" "${MACOS_DIR}/umi-ocr"
+chmod +x "${MACOS_DIR}/umi-ocr"
+
+# Install OCR on-demand installer script
+cp "${BUILD_DIR}/install_ocr.command" "${RESOURCES}/install_ocr.command"
+cp "${BUILD_DIR}/requirements-ocr.txt" "${RESOURCES}/requirements-ocr.txt"
+chmod +x "${RESOURCES}/install_ocr.command"
+
+# ── Copy UmiOCR-data ─────────────────────────────────────────
+
+echo "Copying application data..."
+rsync -a --exclude='__pycache__' \
+         --exclude='*.pyc' \
+         --exclude='.DS_Store' \
+         --exclude='logs/' \
+         --exclude='temp/' \
+         --exclude='temp_doc/' \
+         "${REPO_ROOT}/UmiOCR-data/" "${RESOURCES}/UmiOCR-data/"
+
+# ── Install Python dependencies ──────────────────────────────
+
+SITE_PACKAGES="${RESOURCES}/UmiOCR-data/site-packages"
+
+if [ "${SKIP_DEPS}" = false ]; then
+    echo "Installing core Python dependencies..."
+    "${PYTHON}" -m pip install \
+        --target "${SITE_PACKAGES}" \
+        --upgrade \
+        -r "${BUILD_DIR}/requirements-core.txt" \
+        2>&1 | tail -5
+    echo "  Core dependencies installed to ${SITE_PACKAGES}"
+
+    if [ "${WITH_OCR}" = true ]; then
+        echo "Installing OCR engine dependencies (--with-ocr)..."
+        "${PYTHON}" -m pip install \
+            --target "${SITE_PACKAGES}" \
+            --upgrade \
+            -r "${BUILD_DIR}/requirements-ocr.txt" \
+            2>&1 | tail -5
+        echo "  OCR dependencies installed"
+    else
+        echo "  OCR engine NOT bundled (lightweight build). Users install via install_ocr.command."
+    fi
+else
+    echo "Skipping dependency installation (--skip-deps)"
+fi
+
+# ── Install PySide2 → PySide6 compatibility shim ────────────
+# PySide2 has no Python 3.12+ or macOS arm64 wheels, so we use PySide6.
+# This shim lets the existing codebase's `from PySide2...` imports work.
+echo "Installing PySide2 compatibility shim..."
+if [ -d "${SITE_PACKAGES}/PySide2" ]; then
+    rm -rf "${SITE_PACKAGES}/PySide2"
+fi
+cp -R "${BUILD_DIR}/pyside2_compat/PySide2" "${SITE_PACKAGES}/PySide2"
+echo "  PySide2 → PySide6 shim installed"
+
+# ── Trim PySide6 (remove unused Qt modules) ──────────────────
+# QtWebEngine alone is ~600 MB (Chromium). Remove modules not needed by Umi-OCR.
+echo "Trimming PySide6 unused modules..."
+PYSIDE6="${SITE_PACKAGES}/PySide6"
+TRIM_SIZE_BEFORE=$(du -sm "${PYSIDE6}" | awk '{print $1}')
+
+# Remove development tools
+rm -rf "${PYSIDE6}/Assistant.app" "${PYSIDE6}/Designer.app" "${PYSIDE6}/Linguist.app"
+rm -rf "${PYSIDE6}/include" "${PYSIDE6}/typesystems" "${PYSIDE6}/glue"
+
+# Remove unused Qt frameworks (keep only what Umi-OCR needs)
+QT_LIB="${PYSIDE6}/Qt/lib"
+for fw in QtWebEngine QtWebEngineCore QtWebEngineQuick QtWebChannel \
+          QtDesigner QtDesignerComponents QtHelp QtSql QtTest \
+          Qt3DCore Qt3DRender Qt3DInput Qt3DLogic Qt3DAnimation Qt3DExtras \
+          QtQuick3D QtQuick3DRuntimeRender QtQuick3DAssetImport QtQuick3DAssetUtils \
+          QtQuick3DParticles QtQuick3DEffects QtQuick3DHelpers QtQuick3DUtils \
+          QtGraphs QtCharts QtDataVisualization QtScxml QtStateMachine \
+          QtMultimedia QtMultimediaQuick QtSpatialAudio QtSpeech \
+          QtSensors QtSerialPort QtSerialBus QtBluetooth QtNfc \
+          QtRemoteObjects QtLocation QtPositioning \
+          QtVirtualKeyboard QtPdf QtPdfQuick QtTextToSpeech \
+          QtQmlCompiler QtLabsAnimation QtCoAP QtMQTT QtOpcUa \
+          QtQuickControls2Imagine; do
+    rm -rf "${QT_LIB}/${fw}.framework"
+done
+
+# Remove unused QML modules
+QT_QML="${PYSIDE6}/Qt/qml"
+for mod in QtWebEngine QtWebChannel Qt3D QtMultimedia QtSensors QtTest \
+           QtLocation QtPositioning QtRemoteObjects QtScxml QtCharts; do
+    rm -rf "${QT_QML}/${mod}"
+done
+
+TRIM_SIZE_AFTER=$(du -sm "${PYSIDE6}" | awk '{print $1}')
+echo "  Trimmed PySide6: ${TRIM_SIZE_BEFORE}M → ${TRIM_SIZE_AFTER}M (saved $((TRIM_SIZE_BEFORE - TRIM_SIZE_AFTER))M)"
+
+# Create QtGraphicalEffects → Qt5Compat/GraphicalEffects symlink for QML compat.
+# Qt5 QML code uses "import QtGraphicalEffects 1.15"; Qt6 moved this to Qt5Compat.
+QML_DIR="${SITE_PACKAGES}/PySide6/Qt/qml"
+
+# Create QtGraphicalEffects compat module (Qt5 → Qt6 renamed to Qt5Compat.GraphicalEffects)
+QGE_DIR="${QML_DIR}/QtGraphicalEffects"
+if [ -d "${QML_DIR}/Qt5Compat/GraphicalEffects" ] && [ ! -d "${QGE_DIR}" ]; then
+    mkdir -p "${QGE_DIR}"
+    # Generate qmldir
+    {
+        echo "module QtGraphicalEffects"
+        for qml in "${QML_DIR}/Qt5Compat/GraphicalEffects/"*.qml; do
+            name="$(basename "$qml" .qml)"
+            echo "${name} 1.0 ${name}.qml"
+            echo "${name} 1.15 ${name}.qml"
+        done
+    } > "${QGE_DIR}/qmldir"
+    # Generate wrapper QML files
+    for qml in "${QML_DIR}/Qt5Compat/GraphicalEffects/"*.qml; do
+        name="$(basename "$qml" .qml)"
+        printf 'import Qt5Compat.GraphicalEffects\n%s {}\n' "${name}" > "${QGE_DIR}/${name}.qml"
+    done
+    echo "  QtGraphicalEffects compat module created"
+fi
+
+# Copy Qt5 compat QML overlays (e.g., FileDialog wrapper for version 1.3 imports)
+QT5_COMPAT_SRC="${BUILD_DIR}/qt5compat_qml"
+QT5_COMPAT_DST="${RESOURCES}/UmiOCR-data/qt5compat_qml"
+if [ -d "${QT5_COMPAT_SRC}" ]; then
+    cp -R "${QT5_COMPAT_SRC}" "${QT5_COMPAT_DST}"
+    echo "  Qt5 QML compat overlays installed"
+fi
+
+# ── Bundle Python interpreter (optional) ─────────────────────
+
+# Create a minimal Python distribution inside the app bundle.
+# This makes the .app self-contained — no system Python dependency.
+echo "Bundling Python interpreter..."
+PYTHON_BUNDLE="${RESOURCES}/python"
+PYTHON_REAL="$(${PYTHON} -c "import sys; print(sys.executable)")"
+PYTHON_PREFIX="$(${PYTHON} -c "import sys; print(sys.prefix)")"
+
+mkdir -p "${PYTHON_BUNDLE}/bin"
+mkdir -p "${PYTHON_BUNDLE}/lib"
+
+# Copy Python binary
+cp "${PYTHON_REAL}" "${PYTHON_BUNDLE}/bin/python3"
+chmod +x "${PYTHON_BUNDLE}/bin/python3"
+
+# Copy standard library
+STDLIB_DIR="$(${PYTHON} -c "import sysconfig; print(sysconfig.get_path('stdlib'))")"
+if [ -d "${STDLIB_DIR}" ]; then
+    rsync -a --exclude='__pycache__' \
+             --exclude='*.pyc' \
+             --exclude='test/' \
+             --exclude='tests/' \
+             --exclude='tkinter/' \
+             --exclude='turtledemo/' \
+             --exclude='idlelib/' \
+             --exclude='site-packages/' \
+             --exclude='config-*/' \
+             --exclude='distutils/' \
+             --exclude='pydoc_data/' \
+             --exclude='unittest/' \
+             --exclude='_pyrepl/' \
+             --exclude='turtle.py' \
+             --exclude='doctest.py' \
+             --exclude='pydoc.py' \
+             "${STDLIB_DIR}/" "${PYTHON_BUNDLE}/lib/python${PYTHON_VERSION}/"
+    echo "  Bundled stdlib from ${STDLIB_DIR}"
+fi
+
+# Copy lib-dynload (compiled C extensions)
+DYNLOAD_DIR="${STDLIB_DIR}/lib-dynload"
+if [ -d "${DYNLOAD_DIR}" ]; then
+    mkdir -p "${PYTHON_BUNDLE}/lib/python${PYTHON_VERSION}/lib-dynload"
+    rsync -a "${DYNLOAD_DIR}/" "${PYTHON_BUNDLE}/lib/python${PYTHON_VERSION}/lib-dynload/"
+fi
+
+# Copy all dylibs that Python and its C extensions link against
+PYTHON_LIBDIR="$(${PYTHON} -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR') or '')")"
+if [ -n "${PYTHON_LIBDIR}" ] && [ -d "${PYTHON_LIBDIR}" ]; then
+    # Copy libpython
+    for dylib in "${PYTHON_LIBDIR}"/libpython*.dylib; do
+        [ -f "$dylib" ] && cp "$dylib" "${PYTHON_BUNDLE}/lib/" && echo "  Bundled $(basename "$dylib")"
+    done
+
+    # Find all non-system dylibs referenced by lib-dynload extensions
+    echo "  Scanning C extensions for required dylibs..."
+    DYNLOAD="${PYTHON_BUNDLE}/lib/python${PYTHON_VERSION}/lib-dynload"
+    if [ -d "${DYNLOAD}" ]; then
+        # Collect all unique @rpath dylib references from C extensions
+        RPATH_LIBS="$(for so in "${DYNLOAD}"/*.so; do
+            otool -L "$so" 2>/dev/null
+        done | grep '@rpath/' | awk '{print $1}' | sed 's|@rpath/||' | sort -u || true)"
+
+        for libname in ${RPATH_LIBS}; do
+            if [ ! -f "${PYTHON_BUNDLE}/lib/${libname}" ]; then
+                # Search for the dylib in Python's lib directory, then parent
+                FOUND="$(find "${PYTHON_LIBDIR}" -maxdepth 1 -name "${libname}" 2>/dev/null | head -1)"
+                if [ -z "${FOUND}" ]; then
+                    FOUND="$(find "$(dirname "${PYTHON_LIBDIR}")" -maxdepth 2 -name "${libname}" 2>/dev/null | head -1)"
+                fi
+                if [ -n "${FOUND}" ] && [ -f "${FOUND}" ]; then
+                    cp "${FOUND}" "${PYTHON_BUNDLE}/lib/"
+                    echo "  Bundled ${libname}"
+                fi
+            fi
+        done
+    fi
+
+    # Add @rpath entry so extensions can find the bundled dylibs
+    install_name_tool -add_rpath "${PYTHON_BUNDLE}/lib" "${PYTHON_BUNDLE}/bin/python3" 2>/dev/null || true
+fi
+
+# ── Ad-hoc sign all binaries ─────────────────────────────────
+# macOS kills binaries with invalid code signatures. After copying,
+# the original signatures (from conda, pip, etc.) become invalid.
+# Ad-hoc signing makes them loadable without an Apple Developer cert.
+# This MUST happen before running the bundled python3 (e.g. ensurepip).
+echo "Ad-hoc signing bundled binaries..."
+find "${APP_DIR}" -type f \( -name "python3" -o -name "*.dylib" -o -name "*.so" \) \
+    -exec codesign --force --sign - {} \; 2>/dev/null
+echo "  All binaries signed"
+
+# Bootstrap pip in the bundled Python (must run after ad-hoc signing)
+mkdir -p "${PYTHON_BUNDLE}/lib/python${PYTHON_VERSION}/site-packages"
+echo "  Bootstrapping pip..."
+PYTHONHOME="${PYTHON_BUNDLE}" "${PYTHON_BUNDLE}/bin/python3" -m ensurepip --upgrade 2>&1 | tail -3
+if PYTHONHOME="${PYTHON_BUNDLE}" "${PYTHON_BUNDLE}/bin/python3" -c "import pip" 2>/dev/null; then
+    echo "  pip installed successfully"
+else
+    echo "  ERROR: pip bootstrap failed — OCR on-demand install will not work"
+fi
+
+echo "  Python bundled at ${PYTHON_BUNDLE}"
+
+# ── Code signing (with developer identity) ───────────────────
+
+if [ -n "${SIGN_IDENTITY}" ]; then
+    echo "Code signing with identity: ${SIGN_IDENTITY}"
+    codesign --deep --force --verify --verbose \
+        --sign "${SIGN_IDENTITY}" \
+        --options runtime \
+        --entitlements "${BUILD_DIR}/entitlements.plist" \
+        "${APP_DIR}"
+    echo "  Signed successfully"
+    echo
+    echo "  To notarize, run:"
+    echo "    xcrun notarytool submit dist/Umi-OCR.app.zip --apple-id YOUR_ID --team-id YOUR_TEAM --password YOUR_APP_PASSWORD --wait"
+    echo "    xcrun stapler staple dist/Umi-OCR.app"
+else
+    echo
+    echo "NOTE: App is unsigned. Users may need to bypass Gatekeeper:"
+    echo "  xattr -cr /Applications/Umi-OCR.app"
+fi
+
+# ── Summary ──────────────────────────────────────────────────
+
+APP_SIZE=$(du -sh "${APP_DIR}" | awk '{print $1}')
+echo
+echo "================================================"
+echo "  Build complete!"
+echo "  Output: ${APP_DIR}"
+echo "  Size:   ${APP_SIZE}"
+echo "================================================"
+echo
+echo "To test:  open dist/Umi-OCR.app"
+echo "To create DMG:  ./build_macos/create_dmg.sh"

--- a/build_macos/create_dmg.sh
+++ b/build_macos/create_dmg.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# =============================================================
+# Umi-OCR macOS DMG Creator
+# =============================================================
+#
+# Creates a distributable .dmg disk image from the built .app bundle.
+#
+# Usage:
+#   ./build_macos/create_dmg.sh [--notarize]
+#
+# Prerequisites:
+#   - Run build.sh first to create dist/Umi-OCR.app
+#
+# Output:
+#   dist/Umi-OCR-{version}-macOS.dmg
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DIST_DIR="${REPO_ROOT}/dist"
+APP_DIR="${DIST_DIR}/Umi-OCR.app"
+BUILD_DIR="${REPO_ROOT}/build_macos"
+NOTARIZE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --notarize) NOTARIZE=true; shift ;;
+        *)          echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ── Validate ─────────────────────────────────────────────────
+
+if [ ! -d "${APP_DIR}" ]; then
+    echo "ERROR: ${APP_DIR} not found. Run build.sh first."
+    exit 1
+fi
+
+# ── Read version ─────────────────────────────────────────────
+
+VERSION=$(defaults read "${APP_DIR}/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "unknown")
+
+# Detect architecture
+ARCH="$(uname -m)"
+if [ "${ARCH}" = "arm64" ]; then
+    ARCH_LABEL="arm64"
+else
+    ARCH_LABEL="x86_64"
+fi
+
+DMG_NAME="Umi-OCR-${VERSION}-macOS-${ARCH_LABEL}"
+DMG_PATH="${DIST_DIR}/${DMG_NAME}.dmg"
+DMG_TEMP="${DIST_DIR}/${DMG_NAME}-temp.dmg"
+
+echo "================================================"
+echo "  Creating DMG: ${DMG_NAME}.dmg"
+echo "  Version:  ${VERSION}"
+echo "  Arch:     ${ARCH_LABEL}"
+echo "================================================"
+echo
+
+# ── Clean previous DMG ──────────────────────────────────────
+
+rm -f "${DMG_PATH}" "${DMG_TEMP}"
+
+# ── Create temporary DMG with app + Applications symlink ─────
+
+STAGING="${DIST_DIR}/dmg-staging"
+rm -rf "${STAGING}"
+mkdir -p "${STAGING}"
+
+# Hardlink app instead of copying (instant, same disk)
+echo "Linking app to staging..."
+cp -Rl "${APP_DIR}" "${STAGING}/" 2>/dev/null || {
+    echo "  Hardlink failed, falling back to copy..."
+    cp -R "${APP_DIR}" "${STAGING}/"
+}
+echo "  Done."
+
+# Create Applications symlink (standard macOS drag-to-install)
+ln -s /Applications "${STAGING}/Applications"
+
+# ── Build DMG ────────────────────────────────────────────────
+
+echo "Creating disk image..."
+
+# Create a read-write DMG first
+hdiutil create -volname "Umi-OCR" \
+    -srcfolder "${STAGING}" \
+    -ov -format UDRW \
+    "${DMG_TEMP}"
+
+# Convert to compressed read-only DMG
+hdiutil convert "${DMG_TEMP}" \
+    -format UDZO \
+    -imagekey zlib-level=6 \
+    -o "${DMG_PATH}"
+
+# Clean up
+rm -f "${DMG_TEMP}"
+rm -rf "${STAGING}"
+
+# ── Notarize (optional) ─────────────────────────────────────
+
+if [ "${NOTARIZE}" = true ]; then
+    echo
+    echo "Submitting for notarization..."
+    echo "NOTE: Set these environment variables first:"
+    echo "  APPLE_ID        - your Apple ID email"
+    echo "  APPLE_TEAM_ID   - your Team ID"
+    echo "  APPLE_APP_PWD   - app-specific password"
+    echo
+
+    if [ -z "${APPLE_ID:-}" ] || [ -z "${APPLE_TEAM_ID:-}" ] || [ -z "${APPLE_APP_PWD:-}" ]; then
+        echo "ERROR: Missing notarization credentials. Set APPLE_ID, APPLE_TEAM_ID, APPLE_APP_PWD."
+        exit 1
+    fi
+
+    xcrun notarytool submit "${DMG_PATH}" \
+        --apple-id "${APPLE_ID}" \
+        --team-id "${APPLE_TEAM_ID}" \
+        --password "${APPLE_APP_PWD}" \
+        --wait
+
+    echo "Stapling notarization ticket..."
+    xcrun stapler staple "${DMG_PATH}"
+    echo "Notarization complete."
+fi
+
+# ── Summary ──────────────────────────────────────────────────
+
+DMG_SIZE=$(du -sh "${DMG_PATH}" | awk '{print $1}')
+echo
+echo "================================================"
+echo "  DMG created successfully!"
+echo "  Output: ${DMG_PATH}"
+echo "  Size:   ${DMG_SIZE}"
+echo "================================================"

--- a/build_macos/entitlements.plist
+++ b/build_macos/entitlements.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Allow JIT for ONNX Runtime performance -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+
+    <!-- Allow unsigned executable memory (needed by Python extensions / ONNX Runtime) -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+
+    <!-- Allow loading third-party dylibs (site-packages with C extensions) -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+
+    <!-- Screen capture for screenshot OCR -->
+    <key>com.apple.security.screen-capture.allow</key>
+    <true/>
+
+    <!-- Accessibility for global hotkeys -->
+    <key>com.apple.security.accessibility</key>
+    <true/>
+</dict>
+</plist>

--- a/build_macos/install_ocr.command
+++ b/build_macos/install_ocr.command
@@ -1,0 +1,60 @@
+#!/bin/bash
+# =============================================================
+# Umi-OCR — Install OCR Engine
+# =============================================================
+# Double-click this file to install the OCR engine components.
+# This downloads RapidOCR + ONNX Runtime (~400 MB).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Resolve paths — this script lives in Contents/Resources/
+CONTENTS_DIR="$(dirname "$SCRIPT_DIR")"
+RESOURCES_DIR="${SCRIPT_DIR}"
+UMIOCR_DATA="${RESOURCES_DIR}/UmiOCR-data"
+SITE_PACKAGES="${UMIOCR_DATA}/site-packages"
+REQUIREMENTS="${RESOURCES_DIR}/requirements-ocr.txt"
+
+# Find Python
+if [ -d "${RESOURCES_DIR}/python" ]; then
+    PYTHON="${RESOURCES_DIR}/python/bin/python3"
+else
+    PYTHON="$(which python3 2>/dev/null || echo /usr/bin/python3)"
+fi
+
+echo "================================================"
+echo "  Umi-OCR — OCR Engine Installer"
+echo "================================================"
+echo
+echo "  This will install RapidOCR + ONNX Runtime"
+echo "  Download size: ~100 MB"
+echo "  Installed size: ~400 MB"
+echo
+echo "  Installing to: ${SITE_PACKAGES}"
+echo "  Python: ${PYTHON}"
+echo "================================================"
+echo
+
+if [ ! -f "${REQUIREMENTS}" ]; then
+    echo "ERROR: requirements-ocr.txt not found at ${REQUIREMENTS}"
+    echo "Press any key to exit..."
+    read -n 1
+    exit 1
+fi
+
+echo "Installing OCR dependencies..."
+echo
+"${PYTHON}" -m pip install \
+    --target "${SITE_PACKAGES}" \
+    --upgrade \
+    -r "${REQUIREMENTS}"
+
+echo
+echo "================================================"
+echo "  Installation complete!"
+echo "  Please restart Umi-OCR to use OCR features."
+echo "================================================"
+echo
+echo "Press any key to close..."
+read -n 1

--- a/build_macos/pyside2_compat/PySide2/QtCore.py
+++ b/build_macos/pyside2_compat/PySide2/QtCore.py
@@ -1,0 +1,25 @@
+# PySide2.QtCore → PySide6.QtCore compatibility shim
+
+from PySide6.QtCore import *  # noqa: F401,F403
+from PySide6.QtCore import Qt as _Qt
+
+# In Qt6, these AA_ attributes were removed. The codebase references them
+# in run.py and app_opengl.py. We add them as harmless integer stubs so
+# QGuiApplication.setAttribute() doesn't crash — Qt6 simply ignores
+# unknown attribute values.
+
+# High-DPI scaling is always enabled in Qt6.
+if not hasattr(_Qt, "AA_EnableHighDpiScaling"):
+    _Qt.AA_EnableHighDpiScaling = 20  # original Qt5 enum value
+
+# OpenGL backend selection was removed in Qt6 (uses RHI abstraction).
+if not hasattr(_Qt, "AA_UseDesktopOpenGL"):
+    _Qt.AA_UseDesktopOpenGL = 15
+if not hasattr(_Qt, "AA_UseOpenGLES"):
+    _Qt.AA_UseOpenGLES = 16
+if not hasattr(_Qt, "AA_UseSoftwareOpenGL"):
+    _Qt.AA_UseSoftwareOpenGL = 17
+
+# AA_ShareOpenGLContexts may still exist in some PySide6 builds.
+if not hasattr(_Qt, "AA_ShareOpenGLContexts"):
+    _Qt.AA_ShareOpenGLContexts = 18

--- a/build_macos/pyside2_compat/PySide2/QtGui.py
+++ b/build_macos/pyside2_compat/PySide2/QtGui.py
@@ -1,0 +1,33 @@
+# PySide2.QtGui → PySide6.QtGui compatibility shim
+
+from PySide6.QtGui import *  # noqa: F401,F403
+from PySide6.QtGui import QClipboard as _QClipboard6, QGuiApplication
+
+
+class QClipboard:
+    """PySide2 compatibility wrapper for QClipboard.
+
+    In PySide2, ``QClipboard()`` could be called directly at module level.
+    PySide6 forbids direct construction — you must use
+    ``QGuiApplication.clipboard()``.  This wrapper defers to the real
+    clipboard instance lazily, so existing ``Clipboard = QClipboard()``
+    code keeps working.
+    """
+
+    def __init__(self):
+        self._real = None
+
+    def _clipboard(self):
+        if self._real is None:
+            app = QGuiApplication.instance()
+            if app is not None:
+                self._real = app.clipboard()
+        return self._real
+
+    def __getattr__(self, name):
+        cb = self._clipboard()
+        if cb is not None:
+            return getattr(cb, name)
+        raise RuntimeError(
+            "QClipboard accessed before QGuiApplication is created"
+        )

--- a/build_macos/pyside2_compat/PySide2/QtQml.py
+++ b/build_macos/pyside2_compat/PySide2/QtQml.py
@@ -1,0 +1,3 @@
+# PySide2.QtQml → PySide6.QtQml compatibility shim
+
+from PySide6.QtQml import *  # noqa: F401,F403

--- a/build_macos/pyside2_compat/PySide2/QtQuick.py
+++ b/build_macos/pyside2_compat/PySide2/QtQuick.py
@@ -1,0 +1,3 @@
+# PySide2.QtQuick → PySide6.QtQuick compatibility shim
+
+from PySide6.QtQuick import *  # noqa: F401,F403

--- a/build_macos/pyside2_compat/PySide2/__init__.py
+++ b/build_macos/pyside2_compat/PySide2/__init__.py
@@ -1,0 +1,10 @@
+# PySide2 → PySide6 compatibility shim for Umi-OCR macOS build.
+#
+# PySide2 (Qt5) has no wheels for Python 3.12+ or macOS arm64.
+# This shim allows the existing codebase (which imports PySide2) to run
+# against PySide6 (Qt6) without modifying every import statement.
+
+import PySide6 as _ps6
+
+__version__ = _ps6.__version__
+__version_info__ = getattr(_ps6, "__version_info__", __version__)

--- a/build_macos/qt5compat_qml/QtQuick/Dialogs/FileDialog.qml
+++ b/build_macos/qt5compat_qml/QtQuick/Dialogs/FileDialog.qml
@@ -1,0 +1,45 @@
+// Qt5 FileDialog compatibility wrapper for Qt6
+// Maps Qt5 properties (folder, selectExisting, selectFolder, selectMultiple, fileUrls, nameFilters)
+// to their Qt6 equivalents (currentFolder, fileMode, selectedFiles, nameFilters)
+
+import QtQuick
+import QtQuick.Dialogs as Dialogs6
+
+Dialogs6.FileDialog {
+    id: root
+
+    // Qt5 property: folder (URL) → Qt6: currentFolder
+    property url folder: ""
+    onFolderChanged: {
+        if (folder.toString() !== "") {
+            currentFolder = folder
+        }
+    }
+
+    // Qt5 property: shortcuts.desktop etc.
+    // In Qt6, StandardPaths is used instead. Provide a basic "shortcuts" object.
+    readonly property QtObject shortcuts: QtObject {
+        readonly property url desktop: StandardPaths.writableLocation(StandardPaths.DesktopLocation)
+        readonly property url home: StandardPaths.writableLocation(StandardPaths.HomeLocation)
+        readonly property url documents: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
+        readonly property url pictures: StandardPaths.writableLocation(StandardPaths.PicturesLocation)
+    }
+
+    // Qt5 properties: selectExisting, selectFolder, selectMultiple → Qt6: fileMode
+    property bool selectExisting: true
+    property bool selectFolder: false
+    property bool selectMultiple: false
+
+    fileMode: {
+        if (selectFolder)
+            return FileDialog.OpenFolder
+        if (selectMultiple)
+            return FileDialog.OpenFiles
+        if (selectExisting)
+            return FileDialog.OpenFile
+        return FileDialog.SaveFile
+    }
+
+    // Qt5 property: fileUrls (list of URLs) → Qt6: selectedFiles
+    readonly property var fileUrls: selectedFiles
+}

--- a/build_macos/qt5compat_qml/QtQuick/Dialogs/qmldir
+++ b/build_macos/qt5compat_qml/QtQuick/Dialogs/qmldir
@@ -1,0 +1,3 @@
+module QtQuick.Dialogs
+FileDialog 1.0 FileDialog.qml
+FileDialog 1.3 FileDialog.qml

--- a/build_macos/umi-ocr.sh
+++ b/build_macos/umi-ocr.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Umi-OCR macOS launcher script
+# This script is placed at Contents/MacOS/umi-ocr inside the .app bundle.
+# It sets up the Python environment and launches the application.
+
+set -e
+
+# Resolve the real path of this script (handles symlinks)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONTENTS_DIR="$(dirname "$SCRIPT_DIR")"
+RESOURCES_DIR="${CONTENTS_DIR}/Resources"
+
+# UmiOCR-data lives inside Resources/
+UMIOCR_DATA="${RESOURCES_DIR}/UmiOCR-data"
+
+# Python environment: bundled in Resources/python/ or system Python
+if [ -d "${RESOURCES_DIR}/python" ]; then
+    # Use bundled Python
+    PYTHON="${RESOURCES_DIR}/python/bin/python3"
+    export PATH="${RESOURCES_DIR}/python/bin:${PATH}"
+    export PYTHONHOME="${RESOURCES_DIR}/python"
+else
+    # Fallback: use system Python 3
+    PYTHON="$(which python3 2>/dev/null || echo /usr/bin/python3)"
+fi
+
+# Set the PYSTAND env var so main.py can find the app entry path
+export PYSTAND="${SCRIPT_DIR}/umi-ocr"
+
+# Ensure the working directory is UmiOCR-data
+cd "${UMIOCR_DATA}"
+
+# Add site-packages to Python path
+if [ -d "${UMIOCR_DATA}/site-packages" ]; then
+    export PYTHONPATH="${UMIOCR_DATA}/site-packages:${PYTHONPATH:-}"
+fi
+
+# Set Qt plugin path for PySide6
+PYSIDE6_DIR="${UMIOCR_DATA}/site-packages/PySide6"
+if [ -d "${PYSIDE6_DIR}" ]; then
+    export QT_PLUGIN_PATH="${PYSIDE6_DIR}/Qt/plugins"
+    # Qt5 compat overlay must come BEFORE PySide6 qml path so version 1.x imports resolve first
+    QT5_COMPAT="${UMIOCR_DATA}/qt5compat_qml"
+    if [ -d "${QT5_COMPAT}" ]; then
+        export QML2_IMPORT_PATH="${QT5_COMPAT}:${PYSIDE6_DIR}/Qt/qml"
+        export QML_IMPORT_PATH="${QT5_COMPAT}:${PYSIDE6_DIR}/Qt/qml"
+    else
+        export QML2_IMPORT_PATH="${PYSIDE6_DIR}/Qt/qml"
+        export QML_IMPORT_PATH="${PYSIDE6_DIR}/Qt/qml"
+    fi
+fi
+
+# Use Basic/Fusion style to avoid "native style does not support customization" warnings
+# The macOS native style rejects custom backgrounds/contentItems on Controls.
+export QT_QUICK_CONTROLS_STYLE="${QT_QUICK_CONTROLS_STYLE:-Fusion}"
+
+# Launch the application
+exec "${PYTHON}" "${UMIOCR_DATA}/main.py" "$@"


### PR DESCRIPTION
## Summary
- Full macOS platform layer (darwin_api.py, key_translator.py) implementing the existing Api interface — shortcuts, startfile, hardware control, accessibility/screen recording permission checks
- PySide2→PySide6 compatibility shim so the existing PySide2/Qt5 codebase runs on PySide6/Qt6 without code changes
- Qt5Compat QML overlay for QtQuick.Dialogs version differences
- Cross-platform entry point (main.py) — MessageBox, stdout/stderr, Qt plugin paths now handle all three platforms
- On-demand OCR engine installer with first-launch download dialog
- darwin_RapidOCR-json OCR plugin using RapidOCR with CoreML execution provider
- macOS build pipeline (build.sh, create_dmg.sh) producing .app bundle and DMG

## Bug fixes (not macOS-specific)

- Fix PDF text layer missing on PyMuPDF 1.27+ — fontsize became keyword-only in page.insert_text(); the old positional call silently failed, producing PDFs with no selectable text
- Fix Linux os.startfile() crash — linux_api.py used the Windows-only os.startfile(); replaced with xdg-open
- Add Linux/macOS clipboard support in cmd_client.py (pbcopy/xclip)

## Test plan
- Tested on macOS — app launches, screenshot OCR, batch image OCR, batch document OCR (with text layer verified), system tray, hotkeys, HTTP API
- The PyMuPDF fix and Linux startfile fix are cross-platform corrections that benefit all platforms