### PR TITLE
fix(server): validate Host header on /argv to prevent DNS rebinding RCE

### DIFF
--- a/UmiOCR-data/py_src/server/web_server.py
+++ b/UmiOCR-data/py_src/server/web_server.py
@@ -48,17 +48,44 @@ def _umiocr():
     return UmiAbout["fullname"]
 
 
+# 判断 Host 请求头是否为回环地址。用于防御 DNS rebinding 攻击。
+# Validate the Host header points to a loopback address, to defend
+# against DNS rebinding attacks originating from a malicious web page
+# that resolves an attacker-controlled domain to 127.0.0.1.
+def _isLoopbackHostHeader():
+    host_header = request.environ.get("HTTP_HOST", "")
+    if not host_header:
+        # 没有 Host 头（HTTP/1.0 等），本地命令行客户端使用 urllib 会带该头。
+        # 缺失时保守拒绝，避免被利用。
+        return False
+    # 去除端口
+    hostname = host_header.rsplit(":", 1)[0].strip().lower()
+    # 去除 IPv6 括号
+    if hostname.startswith("[") and hostname.endswith("]"):
+        hostname = hostname[1:-1]
+    return hostname in ("127.0.0.1", "localhost", "::1")
+
+
 # 跨进程接收命令行参数
 @UmiWeb.route("/argv", method="POST")
 def _argv():
     addr = request.environ.get("REMOTE_ADDR")
-    if addr == "127.0.0.1":
-        data = request.json
-        res = CmdServer.execute(data)
-        return res
-    else:
+    if addr != "127.0.0.1":
         msg = "Unauthorized access. Only local requests are allowed.\n此接口只允许本机访问。"
         return HTTPResponse(msg, status=401)
+    # 校验 Host 头，防止 DNS rebinding 通过浏览器跨源调用 /argv 触发任意函数执行
+    # (CWE-94 / CWE-350) —— 该接口可通过 --call_py / --call_qml 调用任意已注册
+    # Python / QML 模块方法，若被恶意网页借助 DNS rebinding 命中，将造成本机
+    # 代码执行。此处仅接受回环主机名的 Host 头。
+    if not _isLoopbackHostHeader():
+        msg = (
+            "Forbidden: invalid Host header.\n"
+            "此接口只允许 Host 为 127.0.0.1 / localhost 的本地请求。"
+        )
+        return HTTPResponse(msg, status=403)
+    data = request.json
+    res = CmdServer.execute(data)
+    return res
 
 
 ocr_server.init(UmiWeb)


### PR DESCRIPTION
## Summary

The local HTTP server exposes `POST /argv`, which forwards its JSON body to `CmdServer.execute()` (`UmiOCR-data/py_src/server/cmd_server.py:455`). `execute()` parses the payload with argparse and honors `--call_py <module> --func <name>` / `--call_qml <module> --func <name>`, invoking arbitrary functions on registered Python/QML modules. Successful exploitation results in local code execution in the context of the Umi-OCR process.

The existing guard only checks `request.environ["REMOTE_ADDR"] == "127.0.0.1"`. That check is bypassable by **DNS rebinding**: an attacker-controlled domain with a short TTL first resolves to a public IP (to pass the browser's same-origin fetch), then to `127.0.0.1`. The browser then issues the malicious `POST /argv` from the attacker's page; the TCP peer address is genuinely `127.0.0.1`, so `REMOTE_ADDR` passes, but the request originated from a remote web page. `CORS_ALLOW_ALL` is set on the server, which further removes any cross-origin friction on the response side.

- CWE-94 (Code Injection) via CWE-350 (Reliance on Reverse DNS / trusted host without validation)
- Affected: `UmiOCR-data/py_src/server/web_server.py` — `_argv()` route handler
- Impact: Any website a user visits while Umi-OCR's HTTP server is running can execute arbitrary registered Python/QML functions locally.

## Fix

Add a Host-header allowlist — the standard defense against DNS rebinding. After the `REMOTE_ADDR` check, `/argv` now also requires `Host` to be one of `127.0.0.1`, `localhost`, or `::1` (port stripped, IPv6 brackets stripped, case-insensitive). A missing `Host` header is rejected conservatively.

The bundled CLI client (`cmd_client.py`) uses `urllib` against `http://127.0.0.1:<port>/argv`, so `urllib` sets `Host: 127.0.0.1:<port>` automatically — legitimate local usage is unaffected. Browser attacks via a rebound domain send `Host: attacker.com`, which is now rejected with HTTP 403.

Diff is minimal: one new helper (`_isLoopbackHostHeader`) plus a single additional check in `_argv`. No behavior change for any other route.

## Testing

- Verified the CLI path: `urllib.request.Request("http://127.0.0.1:PORT/argv", ...)` sets `Host: 127.0.0.1:PORT`, which passes the new check.
- Verified the helper handles the shapes the WSGI layer produces: `127.0.0.1:1234`, `localhost:1234`, `[::1]:1234`, bare `localhost`, mixed case, and empty/missing.
- Manually simulated a rebinding request by sending `POST /argv` with `Host: evil.example` — server now returns HTTP 403 instead of executing the payload.
- Existing legitimate flow (`Umi-OCR --call_py ...` from the CLI) is unchanged.

## Proof of Concept

With Umi-OCR running locally (HTTP server enabled), a request from a browser after a DNS rebind — or, equivalently, any request with a non-loopback `Host` — reaches the handler:

```bash
# Before fix: executes; After fix: 403 Forbidden
curl -X POST http://127.0.0.1:1224/argv \
  -H 'Host: attacker.example' \
  -H 'Content-Type: application/json' \
  --data '["--call_py","utils","--func","runCmd","--argv","[\"calc.exe\"]"]'
```

The actual attack sequence in the wild:
1. Victim runs Umi-OCR with the HTTP server enabled (default port 1224).
2. Victim visits `http://rebind.attacker.tld` (short-TTL A record initially pointing to the attacker's server so the page loads).
3. Attacker's page waits, then flips the DNS record to `127.0.0.1` and issues `fetch("http://rebind.attacker.tld:1224/argv", {method:"POST", body: JSON.stringify(["--call_py", ...])})`.
4. The browser reuses the hostname; TCP connects to `127.0.0.1:1224`; `REMOTE_ADDR` check passes; `CmdServer.execute` runs the attacker-chosen function.

Route/function existence verified in this branch: `UmiOCR-data/py_src/server/web_server.py:70` defines `POST /argv`; `UmiOCR-data/py_src/server/cmd_server.py:455` defines `execute`; `--call_py` / `--call_qml` are registered at `cmd_server.py:406–409`.

## Adversarial review

Before submitting we tried to disprove this. We considered whether the `REMOTE_ADDR == "127.0.0.1"` check alone was sufficient — it isn't, because DNS rebinding intentionally causes the browser to connect to `127.0.0.1` while the origin is attacker-controlled. We checked whether the browser's Same-Origin Policy or CORS would block the `POST` — it doesn't: the server sets permissive CORS headers (`CORS_ALLOW_ALL`), and even without them, a simple `POST` with `Content-Type: text/plain` is a CORS-simple request whose side effects fire regardless of whether the response is readable. We checked whether `cmd_client.py` sets a custom `Host` that our check might break — it uses `urllib`, which derives `Host` from the URL host (`127.0.0.1`), so it's fine. Finally we considered whether the precondition ("victim visits attacker page while Umi-OCR is running") is realistic — Umi-OCR is a long-running desktop app, so the window is typically the whole session.